### PR TITLE
Remove workaround for non-persistent journald

### DIFF
--- a/lab101.md
+++ b/lab101.md
@@ -73,14 +73,6 @@ pasting the commands into container terminal window.
 
 > Note: For `Access Token` select `Workshop`.
 
-Due to a bug, non-persisted Journald is not collected. We can fix this by
-running the following in the container:
-
-```bash
-sed -i "s/var\/log\/journal/run\/log\/journal/g" /etc/otel/collector/fluentd/conf.d/journald.conf
-systemctl restart td-agent
-```
-
 That's it! You have successfully deployed the `splunk-otel-collector` and
 `td-agent` services. Metrics and logs should automatically start being
 collected and sent to the suite. Please confirm you see data on both the


### PR DESCRIPTION
Seems to be resolved already by:
https://github.com/signalfx/splunk-otel-collector/commit/45067f2dd966ac45528858de347ba651c1f3d956